### PR TITLE
Fixed callContrct typo

### DIFF
--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -118,7 +118,7 @@ export class Contract {
     const calldata = this.encodeParams(method, args)
 
     // TODO decode?
-    return this.rpc.callContrct({
+    return this.rpc.callContract({
       address: this.address,
       datahex: calldata,
       ...opts,

--- a/src/QtumRPC.ts
+++ b/src/QtumRPC.ts
@@ -210,7 +210,7 @@ export class QtumRPC extends QtumRPCRaw {
     return this.rawCall("sendtocontract", ...args)
   }
 
-  public callContrct(req: IRPCCallContractRequest): Promise<IRPCCallContractResult> {
+  public callContract(req: IRPCCallContractRequest): Promise<IRPCCallContractResult> {
     const args = [
       req.address,
       req.datahex,


### PR DESCRIPTION
Just fixing a small typo where `callContract` was misspelled as `callContrct`