### PR TITLE
Wrap address utilities (fromhexaddress, gethexaddress)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 .qtum
 .cache
+solar.development.json

--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "eventemitter3"
 
 const {
   logDecoder,
-} = require("ethjs-abi") as IETHABI
+} = require("qtumjs-ethjs-abi") as IETHABI
 
 import {
   decodeOutputs,
@@ -243,11 +243,9 @@ export class Contract {
     this.methodMap = new MethodMap(info.abi)
     this.address = info.address
 
-    if (opts.logDecoder) {
-      this._logDecoder = opts.logDecoder
-    }
+    this._logDecoder = opts.logDecoder || new ContractLogDecoder(this.info.abi)
 
-    this._useBigNumber = this._useBigNumber || false
+    this._useBigNumber = false
   }
 
   public encodeParams(method: string, args: any[] = []): string {
@@ -616,11 +614,6 @@ export class Contract {
   }
 
   private get logDecoder(): ContractLogDecoder {
-    if (this._logDecoder) {
-      return this._logDecoder
-    }
-
-    this._logDecoder = new ContractLogDecoder(this.info.abi)
     return this._logDecoder
   }
 

--- a/src/QtumRPC.ts
+++ b/src/QtumRPC.ts
@@ -409,4 +409,12 @@ export class QtumRPC extends QtumRPCRaw {
     this._hasTxWaitSupport = helpmsg.split("\n")[0].indexOf("waitconf") !== -1
     return this._hasTxWaitSupport
   }
+
+  public async fromHexAddress(hexAddress: string): Promise<string> {
+    return this.rawCall("fromhexaddress", [hexAddress])
+  }
+
+  public async getHexAddress(address: string): Promise<string> {
+    return this.rawCall("gethexaddress", [address])
+  }
 }

--- a/src/QtumRPCRaw.ts
+++ b/src/QtumRPCRaw.ts
@@ -26,6 +26,8 @@ export class QtumRPCRaw {
   private _api: AxiosInstance
 
   constructor(private _baseURL: string) {
+    this.idNonce = 0
+
     const url = new URL(_baseURL)
 
     const config: AxiosRequestConfig = {

--- a/src/QtumRPC_test.ts
+++ b/src/QtumRPC_test.ts
@@ -42,5 +42,13 @@ describe("QtumRPC", () => {
     })
   })
 
+  it("can convert a hex address to a p2pkh address", async () => {
+    const p2pkhAddress = await rpc.fromHexAddress("b22cbfd8dffcd4e0120279c2cc41315fac2335e2")
+    assert.strictEqual(p2pkhAddress, "qZoV3RKeHaxKM5RnuZdA5bwoYTCH73QLrE")
+  })
 
+  it("can convert a p2pkh address to a hex address", async () => {
+    const hexAddress = await rpc.getHexAddress("qZoV3RKeHaxKM5RnuZdA5bwoYTCH73QLrE")
+    assert.strictEqual(hexAddress, "b22cbfd8dffcd4e0120279c2cc41315fac2335e2")
+  })
 })


### PR DESCRIPTION
Simple chore PR. Wraps `fromhexaddress` and `gethexaddress` into `rpc.fromHexAddress(hexAddress: string): Promise<string>` and `rpc.getHexAddress(address: string): Promise<string>`.